### PR TITLE
Fix bug in logout

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -39,7 +39,7 @@ class AuthController extends Controller
      */
     public function __construct()
     {
-        $this->middleware($this->guestMiddleware(), ['except' => 'logout']);
+        $this->middleware($this->guestMiddleware(), ['except' => 'getLogout']);
     }
 
     /**


### PR DESCRIPTION
In your routes file, you explicitly specify the logout route to the getLogout function, so you have to explicitly define it to the exception to guest middleware
